### PR TITLE
chore: update default comment

### DIFF
--- a/packages/evmcrispr-terminal/src/utils/useTerminal.ts
+++ b/packages/evmcrispr-terminal/src/utils/useTerminal.ts
@@ -24,7 +24,7 @@ export const useTerminal = () => {
   const [code, setCode] = useCodeState(
     `# Available commands:
 
-connect <dao> <...path> [@context:https://yoursite.com]
+connect <dao> <...path> [--context https://yoursite.com]
 install <repo> [...initParams]
 grant <entity> <app> <role> [permissionManager]
 revoke <entity> <app> <role>


### PR DESCRIPTION
Small fix on the default comment to prevent confusing users with the old `context` input.

 Otherwise, if we use the old format we get: `Error: First line must be a connect statement.` with any more details.