### PR TITLE
Patch version v0.10.1

### DIFF
--- a/.changeset/rich-countries-pay.md
+++ b/.changeset/rich-countries-pay.md
@@ -1,0 +1,5 @@
+---
+'@1hive/evmcrispr': patch
+---
+
+This patch includes a fix to the `aragon:install` command, which had a bug that prevented installing many instances of the same app.

--- a/packages/evmcrispr-terminal/package.json
+++ b/packages/evmcrispr-terminal/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "private": true,
   "dependencies": {
-    "@1hive/evmcrispr": "0.10.0",
+    "@1hive/evmcrispr": "0.10.1",
     "@chakra-ui/anatomy": "^2.1.0",
     "@chakra-ui/icons": "^2.0.14",
     "@chakra-ui/merge-utils": "^2.0.5",

--- a/packages/evmcrispr-terminal/src/pages/Terminal.tsx
+++ b/packages/evmcrispr-terminal/src/pages/Terminal.tsx
@@ -176,6 +176,10 @@ function TitleInput() {
   const [documentTitle, setDocumentTitle] = useState(title);
 
   useEffect(() => {
+    setDocumentTitle(title);
+  }, [title]);
+
+  useEffect(() => {
     document.title = documentTitle
       ? `${documentTitle} - EVMcrispr Terminal`
       : 'EVMcrispr Terminal';

--- a/packages/evmcrispr/package.json
+++ b/packages/evmcrispr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1hive/evmcrispr",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "codename": "collective wisdom",
   "license": "GPL-3.0",
   "description": "A library that encapsulates actions in EVM scripts for DAOs",

--- a/packages/evmcrispr/src/modules/aragonos/commands/install.ts
+++ b/packages/evmcrispr/src/modules/aragonos/commands/install.ts
@@ -80,8 +80,8 @@ const setApp = (
   dao.appArtifactCache.set(app.codeAddress, artifact);
   dao.appCache.set(app.name, app);
 
-  bindingsManager.setBinding(app.codeAddress, app.abiInterface, ABI);
-  bindingsManager.setBinding(app.address, app.abiInterface, ABI);
+  bindingsManager.setBinding(app.codeAddress, app.abiInterface, ABI, false, undefined, true);
+  bindingsManager.setBinding(app.address, app.abiInterface, ABI, false, undefined, true);
 
   if (!bindingsManager.hasBinding(app.name, ADDR)) {
     bindingsManager.setBinding(app.name, app.address, ADDR);


### PR DESCRIPTION
This patch includes a fix to the `aragon:install` command, which had a bug that prevented installing many instances of the same app.